### PR TITLE
DEV-2064 Transform preservation metadata to mhs

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,17 +62,34 @@ def extract_metadata(path: str):
 
     for filepath, fixity in bag.entries.items():
         if regex.match(filepath):
-            metadata["md5"] = fixity["md5"]
-            metadata["basename"] = Path(filepath).name
             metadata["filename"] = filepath
             metadata["file_extension"] = Path(filepath).suffix
 
-    # Metadata from mets.xml
+    # Metadata from package mets.xml
     mets_path = Path(path, "data/mets.xml")
     root = etree.parse(str(mets_path))
     metadata["cp_id"] = root.xpath(
         "//*[local-name() = 'metsHdr']/*[local-name() = 'agent' and @ROLE = 'CREATOR' and @TYPE = 'ORGANIZATION'][1]/*[local-name() = 'note' and @*[local-name()='NOTETYPE'] = 'IDENTIFICATIONCODE']/text()"
     )[0]
+
+    # Metadata from the preservation data of the representation
+    premis_path = Path(
+        path, "data/representations/representation_1/metadata/preservation/premis.xml"
+    )
+    premis_namespaces = {
+        "premis": "http://www.loc.gov/premis/v3",
+        "xsi": "http://www.w3.org/2001/XMLSchemainstance",
+    }
+    root_premis = etree.parse(str(premis_path))
+    metadata["original_filename"] = root_premis.xpath(
+        "/premis:premis/premis:object[@xsi:type='file']/premis:originalName/text()",
+        namespaces=premis_namespaces,
+    )[0]
+    metadata["md5"] = root_premis.xpath(
+        "/premis:premis/premis:object[@xsi:type='file']/premis:objectCharacteristics/premis:fixity/premis:messageDigest/text()",
+        namespaces=premis_namespaces,
+    )[0]
+
     # Generated metadata
     metadata["pid"] = get_pid(configParser.app_cfg["aip-creator"]["pid_url"])
 
@@ -81,7 +98,7 @@ def extract_metadata(path: str):
 
 def create_sidecar(path: str, metadata: dict):
     # Parameters not present in the input XML
-    basename = metadata["basename"]
+    original_filename = metadata["original_filename"]
     cp_id = metadata["cp_id"]
     md5 = metadata["md5"]
     pid = metadata["pid"]
@@ -102,7 +119,7 @@ def create_sidecar(path: str, metadata: dict):
         cp_id=etree.XSLT.strparam(cp_id),
         sp_name=etree.XSLT.strparam(sp_name),
         pid=etree.XSLT.strparam(pid),
-        dc_source=etree.XSLT.strparam(basename),
+        original_filename=etree.XSLT.strparam(original_filename),
         md5=etree.XSLT.strparam(md5),
     ).getroot()
     return etree.tostring(tr, pretty_print=True, encoding="UTF-8", xml_declaration=True)

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ def extract_metadata(path: str):
     )
     premis_namespaces = {
         "premis": "http://www.loc.gov/premis/v3",
-        "xsi": "http://www.w3.org/2001/XMLSchemainstance",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
     }
     root_premis = etree.parse(str(premis_path))
     metadata["original_filename"] = root_premis.xpath(

--- a/metadata.xslt
+++ b/metadata.xslt
@@ -3,7 +3,7 @@
     <xsl:param name="cp_id" />
     <xsl:param name="sp_name" />
     <xsl:param name="pid" />
-    <xsl:param name="dc_source" />
+    <xsl:param name="original_filename" />
     <xsl:param name="md5" />
     <xsl:template match="premis:object">
         <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/22.1/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/22.1/mh/" version="22.1">
@@ -28,10 +28,6 @@
                 <xsl:element name="PID">
                     <xsl:value-of select="$pid" />
                 </xsl:element>
-                <!-- source -->
-                <xsl:element name="dc_source">
-                    <xsl:value-of select="$dc_source" />
-                </xsl:element>
                 <!-- md5 -->
                 <xsl:element name="md5">
                     <xsl:value-of select="$md5" />
@@ -43,6 +39,9 @@
                 <!-- Other IDs -->
                 <xsl:element name="dc_identifier_localids">
                     <xsl:apply-templates select="premis:objectIdentifier/premis:objectIdentifierType[not(text() = 'local_id')]" />
+                    <xsl:element name="bestandsnaam">
+                        <xsl:value-of select="$original_filename" />
+                    </xsl:element>
                 </xsl:element>
                 <!-- Created -->
                 <xsl:apply-templates select="dcterms:created" />

--- a/tests/resources/mhs.xml
+++ b/tests/resources/mhs.xml
@@ -8,11 +8,11 @@
     <CP_id>CP ID</CP_id>
     <sp_name>SP name</sp_name>
     <PID>PID</PID>
-    <dc_source>basename</dc_source>
     <md5>md5</md5>
     <dc_identifier_localid>localid</dc_identifier_localid>
     <dc_identifier_localids>
       <Object_number>objnum</Object_number>
+      <bestandsnaam>name</bestandsnaam>
     </dc_identifier_localids>
     <dcterms_created>2022-03-29</dcterms_created>
     <dcterms_issued>2022-03-30</dcterms_issued>

--- a/tests/test_medatata.py
+++ b/tests/test_medatata.py
@@ -14,7 +14,7 @@ def test_transform():
     cp_id = "CP ID"
     sp_name = "SP name"
     pid = "PID"
-    basename = "basename"
+    original_filename = "name"
     md5 = "md5"
 
     # Act
@@ -25,7 +25,7 @@ def test_transform():
         cp_id=etree.XSLT.strparam(cp_id),
         sp_name=etree.XSLT.strparam(sp_name),
         pid=etree.XSLT.strparam(pid),
-        dc_source=etree.XSLT.strparam(basename),
+        original_filename=etree.XSLT.strparam(original_filename),
         md5=etree.XSLT.strparam(md5),
     )
     transformed_xml = etree.tostring(


### PR DESCRIPTION
Get the md5 and original filename from the preservation metadata on
the representation level.

The original filename is transformed to `/mhs/Dynamic/dc_identifiers_localids/bestandsnaam`
instead of `/mhs/Dynamic/dc_source`.