### PR TITLE
DEV-2104 Set sp to borndigital and add ingest_workflow.

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,7 +106,8 @@ def create_sidecar(path: str, metadata: dict):
     cp_id = metadata["cp_id"]
     md5 = metadata["md5"]
     pid = metadata["pid"]
-    sp_name = "sipin"
+    # Workaround to bypass MH codec check (DEV-2104).
+    sp_name = "borndigital"
 
     # The XSLT
     xslt_path = Path("metadata.xslt")

--- a/metadata.xslt
+++ b/metadata.xslt
@@ -17,6 +17,8 @@
             </xsl:element>
             <!-- Dynamic-->
             <xsl:element name="mhs:Dynamic">
+                <!-- Real workflow name (DEV-2104) -->
+                <xsl:element name="ingest_workflow">sipin</xsl:element>
                 <!-- CP (NAME)) -->
                 <xsl:element name="CP">
                     <xsl:value-of select="$cp_name" />

--- a/tests/resources/mhs.xml
+++ b/tests/resources/mhs.xml
@@ -5,6 +5,7 @@
     <mh:Description>Dit is een beschrijving</mh:Description>
   </mhs:Descriptive>
   <mhs:Dynamic>
+    <ingest_workflow>sipin</ingest_workflow>
     <CP>CP name</CP>
     <CP_id>CP ID</CP_id>
     <sp_name>SP name</sp_name>


### PR DESCRIPTION
In order to bypass MH's codec check we set `sp_name` to `borndigital`. `ingest_workflow` is added so we can differentiate real borndigital material and sipin material.