### PR TITLE
DEV-2110 Changes to `dc_contributors`

### DIFF
--- a/metadata.xslt
+++ b/metadata.xslt
@@ -272,13 +272,28 @@
         </xsl:element>
     </xsl:template>
     <!-- Contributors -->
+    <xsl:template match="dcterms:contributor[@schema:roleName='aanwezig']">
+        <xsl:element name="Aanwezig">
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
     <xsl:template match="dcterms:contributor[@schema:roleName='adviseur']">
         <xsl:element name="Adviseur">
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>
+    <xsl:template match="dcterms:contributor[@schema:roleName='afwezig']">
+        <xsl:element name="Afwezig">
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
     <xsl:template match="dcterms:contributor[@schema:roleName='arrangeur']">
         <xsl:element name="Arrangeur">
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="dcterms:contributor[@schema:roleName='archivaris']">
+        <xsl:element name="Archivaris">
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>
@@ -328,12 +343,22 @@
         </xsl:element>
     </xsl:template>
     <xsl:template match="dcterms:contributor[@schema:roleName='decorontwerper']">
-        <xsl:element name="Decorontwerper">
+        <xsl:element name="DecorOntwerper">
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="dcterms:contributor[@schema:roleName='digitaliseringspartner']">
+        <xsl:element name="Digitaliseringspartner">
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>
     <xsl:template match="dcterms:contributor[@schema:roleName='dirigent']">
         <xsl:element name="Dirigent">
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="dcterms:contributor[@schema:roleName='dramaturg']">
+        <xsl:element name="Dramaturg">
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>
@@ -347,8 +372,18 @@
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>
+    <xsl:template match="dcterms:contributor[@schema:roleName='geluidsman']">
+        <xsl:element name="Geluidsman">
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="dcterms:contributor[@schema:roleName='grafisch_ontwerper']">
+        <xsl:element name="GrafischOntwerper">
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
     <xsl:template match="dcterms:contributor[@schema:roleName='kostuumontwerper']">
-        <xsl:element name="Kostuumontwerper">
+        <xsl:element name="KostuumOntwerper">
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>
@@ -413,12 +448,17 @@
         </xsl:element>
     </xsl:template>
     <xsl:template match="dcterms:contributor[@schema:roleName='technisch_adviseur']">
-        <xsl:element name="Technischadviseur">
+        <xsl:element name="TechnischAdviseur">
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>
     <xsl:template match="dcterms:contributor[@schema:roleName='uitvoerder']">
         <xsl:element name="Uitvoerder">
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="dcterms:contributor[@schema:roleName='verontschuldigd']">
+        <xsl:element name="Verontschuldigd">
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>
@@ -429,6 +469,11 @@
     </xsl:template>
     <xsl:template match="dcterms:contributor[@schema:roleName='verteller']">
         <xsl:element name="Verteller">
+            <xsl:value-of select="text()" />
+        </xsl:element>
+    </xsl:template>
+    <xsl:template match="dcterms:contributor[@schema:roleName='voorzitter']">
+        <xsl:element name="Voorzitter">
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>

--- a/tests/resources/dc.xml
+++ b/tests/resources/dc.xml
@@ -41,7 +41,10 @@
   <dcterms:publisher>Publisher</dcterms:publisher>
   <dcterms:language>Nederlands</dcterms:language>
   <dcterms:language>Engels</dcterms:language>
+  <dcterms:contributor schema:roleName="aanwezig">Aanwezig</dcterms:contributor>
   <dcterms:contributor schema:roleName="adviseur">Adviseur</dcterms:contributor>
+  <dcterms:contributor schema:roleName="afwezig">Afwezig</dcterms:contributor>
+  <dcterms:contributor schema:roleName="archivaris">Archivaris</dcterms:contributor>
   <dcterms:contributor schema:roleName="arrangeur">Arrangeur</dcterms:contributor>
   <dcterms:contributor schema:roleName="artistiek_directeur">Artistiek directeur</dcterms:contributor>
   <dcterms:contributor schema:roleName="assistent">Assistent</dcterms:contributor>
@@ -53,9 +56,13 @@
   <dcterms:contributor schema:roleName="commentator">Commentator</dcterms:contributor>
   <dcterms:contributor schema:roleName="componist">Componist</dcterms:contributor>
   <dcterms:contributor schema:roleName="decorontwerper">Decorontwerper</dcterms:contributor>
+  <dcterms:contributor schema:roleName="digitaliseringspartner">Digitaliseringspartner</dcterms:contributor>
   <dcterms:contributor schema:roleName="dirigent">Dirigent</dcterms:contributor>
+  <dcterms:contributor schema:roleName="dramaturg">Dramaturg</dcterms:contributor>
   <dcterms:contributor schema:roleName="fotografie">Fotografie</dcterms:contributor>
   <dcterms:contributor schema:roleName="geluid">Geluid</dcterms:contributor>
+  <dcterms:contributor schema:roleName="geluidsman">Geluidsman</dcterms:contributor>
+  <dcterms:contributor schema:roleName="grafisch_ontwerper">Grafisch ontwerper</dcterms:contributor>
   <dcterms:contributor schema:roleName="kostuumontwerper">Kostuumontwerper</dcterms:contributor>
   <dcterms:contributor schema:roleName="kunstenaar">Kunstenaar</dcterms:contributor>
   <dcterms:contributor schema:roleName="make-up">Make-up</dcterms:contributor>
@@ -71,8 +78,10 @@
   <dcterms:contributor schema:roleName="sponsor">Sponsor</dcterms:contributor>
   <dcterms:contributor schema:roleName="technisch_adviseur">Technisch adviseur</dcterms:contributor>
   <dcterms:contributor schema:roleName="uitvoerder">Uitvoerder</dcterms:contributor>
+  <dcterms:contributor schema:roleName="verontschuldigd">Verontschuldigd</dcterms:contributor>
   <dcterms:contributor schema:roleName="vertaler">Vertaler</dcterms:contributor>
   <dcterms:contributor schema:roleName="verteller">Verteller</dcterms:contributor>
+  <dcterms:contributor schema:roleName="voorzitter">Voorzitter</dcterms:contributor>
   <dcterms:creator schema:roleName="acteur">Acteur</dcterms:creator>
   <dcterms:creator schema:roleName="archiefvormer">Archiefvormer</dcterms:creator>
   <dcterms:creator schema:roleName="auteur">Auteur</dcterms:creator>

--- a/tests/resources/mhs.xml
+++ b/tests/resources/mhs.xml
@@ -66,7 +66,10 @@
       <multiselect>Engels</multiselect>
     </dc_languages>
     <dc_contributors>
+      <Aanwezig>Aanwezig</Aanwezig>
       <Adviseur>Adviseur</Adviseur>
+      <Afwezig>Afwezig</Afwezig>
+      <Archivaris>Archivaris</Archivaris>
       <Arrangeur>Arrangeur</Arrangeur>
       <ArtistiekDirecteur>Artistiek directeur</ArtistiekDirecteur>
       <Assistent>Assistent</Assistent>
@@ -77,11 +80,15 @@
       <Co-producer>Coproducer</Co-producer>
       <Commentator>Commentator</Commentator>
       <Componist>Componist</Componist>
-      <Decorontwerper>Decorontwerper</Decorontwerper>
+      <DecorOntwerper>Decorontwerper</DecorOntwerper>
+      <Digitaliseringspartner>Digitaliseringspartner</Digitaliseringspartner>
       <Dirigent>Dirigent</Dirigent>
+      <Dramaturg>Dramaturg</Dramaturg>
       <Fotografie>Fotografie</Fotografie>
       <Geluid>Geluid</Geluid>
-      <Kostuumontwerper>Kostuumontwerper</Kostuumontwerper>
+      <Geluidsman>Geluidsman</Geluidsman>
+      <GrafischOntwerper>Grafisch ontwerper</GrafischOntwerper>
+      <KostuumOntwerper>Kostuumontwerper</KostuumOntwerper>
       <Kunstenaar>Kunstenaar</Kunstenaar>
       <Make-up>Make-up</Make-up>
       <Muzikant>Muzikant</Muzikant>
@@ -94,10 +101,12 @@
       <Scenarist>Scenarist</Scenarist>
       <Soundtrack>Soundtrack</Soundtrack>
       <Sponsor>Sponsor</Sponsor>
-      <Technischadviseur>Technisch adviseur</Technischadviseur>
+      <TechnischAdviseur>Technisch adviseur</TechnischAdviseur>
       <Uitvoerder>Uitvoerder</Uitvoerder>
+      <Verontschuldigd>Verontschuldigd</Verontschuldigd>
       <Vertaler>Vertaler</Vertaler>
       <Verteller>Verteller</Verteller>
+      <Voorzitter>Voorzitter</Voorzitter>
     </dc_contributors>
     <dc_creators>
       <Acteur>Acteur</Acteur>


### PR DESCRIPTION
Added the following missing contributors:
 - Aanwezig
 - Afwezig
 - Archivaris
 - Digitaliseringspartner
 - Dramaturg
 - Geluidsman
 - GrafischOntwerper
 - Verontschuldigd
 - Voorzitter

 Some fields were not according to the MediaHaven MHS metadatamodel spec:
 - Decorontwerper -> DecorOntwerper
 - Kostuumontwerper -> KostuumOntwerper
 - Technischadviseur -> TechnischAdviseur