### PR TITLE
 DEV-2079 Implement SIP spec 1.0 changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,11 +85,11 @@ def extract_metadata(path: str):
     }
     root_premis = etree.parse(str(premis_path))
     metadata["original_filename"] = root_premis.xpath(
-        "/premis:premis/premis:object[@xsi:type='file']/premis:originalName/text()",
+        "/premis:premis/premis:object[@xsi:type='premis:file']/premis:originalName/text()",
         namespaces=premis_namespaces,
     )[0]
     metadata["md5"] = root_premis.xpath(
-        "/premis:premis/premis:object[@xsi:type='file']/premis:objectCharacteristics/premis:fixity/premis:messageDigest/text()",
+        "/premis:premis/premis:object[@xsi:type='premis:file']/premis:objectCharacteristics/premis:fixity/premis:messageDigest/text()",
         namespaces=premis_namespaces,
     )[0]
 
@@ -113,8 +113,9 @@ def create_sidecar(path: str, metadata: dict):
     xslt = etree.parse(str(xslt_path.resolve()))
 
     # Descriptive metadata
-    # TODO: Get the path dynamically
+    # TODO: Get the paths dynamically
     metadata_path = Path(path, "data/metadata/descriptive/dc.xml")
+    premis_path = Path(path, "data/metadata/preservation/premis.xml")
 
     # XSLT transformation
     transform = etree.XSLT(xslt)
@@ -126,6 +127,7 @@ def create_sidecar(path: str, metadata: dict):
         pid=etree.XSLT.strparam(pid),
         original_filename=etree.XSLT.strparam(original_filename),
         md5=etree.XSLT.strparam(md5),
+        premis_path=etree.XSLT.strparam(str(premis_path)),
     ).getroot()
     return etree.tostring(tr, pretty_print=True, encoding="UTF-8", xml_declaration=True)
 

--- a/metadata.xslt
+++ b/metadata.xslt
@@ -39,8 +39,6 @@
                 <xsl:element name="md5">
                     <xsl:value-of select="$md5" />
                 </xsl:element>
-                <!-- PID -->
-                <!-- <xsl:apply-templates select="dcterms:identifier" /> -->
                 <!-- local ID -->
                 <xsl:apply-templates select="premis:objectIdentifier/premis:objectIdentifierType[text() = 'local_id']" />
                 <!-- Other IDs -->

--- a/metadata.xslt
+++ b/metadata.xslt
@@ -6,6 +6,7 @@
     <xsl:param name="pid" />
     <xsl:param name="original_filename" />
     <xsl:param name="md5" />
+    <xsl:param name="premis_path" />
     <xsl:template match="metadata">
         <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/22.1/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/22.1/mh/" version="22.1">
             <!-- Descriptive -->
@@ -40,10 +41,10 @@
                     <xsl:value-of select="$md5" />
                 </xsl:element>
                 <!-- local ID -->
-                <xsl:apply-templates select="premis:objectIdentifier/premis:objectIdentifierType[text() = 'local_id']" />
+                <xsl:apply-templates select="document($premis_path)/premis:premis/premis:object/premis:objectIdentifier/premis:objectIdentifierType[text() = 'local_id']" />
                 <!-- Other IDs -->
                 <xsl:element name="dc_identifier_localids">
-                    <xsl:apply-templates select="premis:objectIdentifier/premis:objectIdentifierType[not(text() = 'local_id')]" />
+                    <xsl:apply-templates select="document($premis_path)/premis:premis/premis:object/premis:objectIdentifier/premis:objectIdentifierType[not(text() = 'local_id' or text() = 'uuid')]" />
                     <xsl:element name="Bestandsnaam">
                         <xsl:value-of select="$original_filename" />
                     </xsl:element>

--- a/metadata.xslt
+++ b/metadata.xslt
@@ -6,7 +6,7 @@
     <xsl:param name="pid" />
     <xsl:param name="original_filename" />
     <xsl:param name="md5" />
-    <xsl:template match="premis:object">
+    <xsl:template match="metadata">
         <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/22.1/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/22.1/mh/" version="22.1">
             <!-- Descriptive -->
             <xsl:element name="mhs:Descriptive">

--- a/tests/resources/dc.xml
+++ b/tests/resources/dc.xml
@@ -1,4 +1,4 @@
-<premis:object xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ebucore="urn:ebu:metadata-schema:ebucore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
+<metadata xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ebucore="urn:ebu:metadata-schema:ebucore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
   <dcterms:identifier>PID</dcterms:identifier>
   <premis:objectIdentifier>
     <premis:objectIdentifierType>local_id</premis:objectIdentifierType>
@@ -142,4 +142,4 @@
     </dcterms:hasPart>
   </dcterms:isPartOf>
   <ebucore:type>Object type</ebucore:type>
-</premis:object>
+</metadata>

--- a/tests/resources/dc.xml
+++ b/tests/resources/dc.xml
@@ -1,5 +1,4 @@
 <metadata xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ebucore="urn:ebu:metadata-schema:ebucore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
-  <dcterms:identifier>PID</dcterms:identifier>
   <premis:objectIdentifier>
     <premis:objectIdentifierType>local_id</premis:objectIdentifierType>
     <premis:objectIdentifierValue>localid</premis:objectIdentifierValue>

--- a/tests/resources/dc.xml
+++ b/tests/resources/dc.xml
@@ -1,12 +1,4 @@
-<metadata xmlns:premis="http://www.loc.gov/premis/v3" xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ebucore="urn:ebu:metadata-schema:ebucore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
-  <premis:objectIdentifier>
-    <premis:objectIdentifierType>local_id</premis:objectIdentifierType>
-    <premis:objectIdentifierValue>localid</premis:objectIdentifierValue>
-  </premis:objectIdentifier>
-  <premis:objectIdentifier>
-    <premis:objectIdentifierType>Object_number</premis:objectIdentifierType>
-    <premis:objectIdentifierValue>objnum</premis:objectIdentifierValue>
-  </premis:objectIdentifier>
+<metadata xmlns:meemoo="https://data.hetarchief.be/ns/algemeen#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012" xmlns:ebucore="urn:ebu:metadata-schema:ebucore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:viaa="http://www.vrt.be/mig/viaa/api">
   <dcterms:created xsi:type="EDTF-level1">2022-03-29</dcterms:created>
   <dcterms:issued xsi:type="EDTF-level1">2022-03-30</dcterms:issued>
   <dcterms:title>Dit is een titel</dcterms:title>

--- a/tests/resources/premis.xml
+++ b/tests/resources/premis.xml
@@ -1,0 +1,24 @@
+<premis:premis xmlns:premis="http://www.loc.gov/premis/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
+    <premis:object xsi:type="premis:intellectualEntity">
+        <premis:objectIdentifier>
+            <premis:objectIdentifierType>uuid</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>865b767d-05f9-49d5-ba54-e9e82acec30d</premis:objectIdentifierValue>
+        </premis:objectIdentifier>
+        <premis:objectIdentifier>
+            <premis:objectIdentifierType>local_id</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>localid</premis:objectIdentifierValue>
+        </premis:objectIdentifier>
+        <premis:objectIdentifier>
+            <premis:objectIdentifierType>Object_number</premis:objectIdentifierType>
+            <premis:objectIdentifierValue>objnum</premis:objectIdentifierValue>
+        </premis:objectIdentifier>
+        <premis:relationship>
+            <premis:relationshipType authority="relationshipType" authorityURI="http://id.loc.gov/vocabulary/preservation/relationshipType" valueURI="http://id.loc.gov/vocabulary/preservation/relationshipType/str">structural</premis:relationshipType>
+            <premis:relationshipSubtype authority="relationshipSubType" authorityURI="http://id.loc.gov/vocabulary/preservation/relationshipSubType" valueURI="http://id.loc.gov/vocabulary/preservation/relationshipSubType/isr">is represented by</premis:relationshipSubtype>
+            <premis:relatedObjectIdentifier>
+                <premis:relatedObjectIdentifierType>UUID</premis:relatedObjectIdentifierType>
+                <premis:relatedObjectIdentifierValue>c7a2fe3d-81f0-4d48-a5e8-afdee96aeace</premis:relatedObjectIdentifierValue>
+            </premis:relatedObjectIdentifier>
+        </premis:relationship>
+    </premis:object>
+</premis:premis>

--- a/tests/test_medatata.py
+++ b/tests/test_medatata.py
@@ -10,6 +10,7 @@ from tests import load_resource
 def test_transform():
     # Arrange
     metadata_path = Path("tests", "resources", "dc.xml")
+    premis_path = Path("tests", "resources", "premis.xml")
     xslt_path = Path("metadata.xslt")
     cp_name = "CP name"
     cp_id = "CP ID"
@@ -29,6 +30,7 @@ def test_transform():
         pid=etree.XSLT.strparam(pid),
         original_filename=etree.XSLT.strparam(original_filename),
         md5=etree.XSLT.strparam(md5),
+        premis_path=etree.XSLT.strparam(str(premis_path)),
     )
     transformed_xml = etree.tostring(
         transformed,


### PR DESCRIPTION
Descriptive metadata (on package level):
 - `<premis:object>` should be `<metadata>`.
 - The local_id(s) described as premis nodes need to be moved to the corresponding preservation metadata.

Preservation metadata on package level:
 - Add the aforementioned "descriptive" premis data.