### PR TITLE
DEV-2173 Map sp_name correctly in case of XDCAM

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,7 +106,6 @@ def create_sidecar(path: str, metadata: dict):
     cp_id = metadata["cp_id"]
     md5 = metadata["md5"]
     pid = metadata["pid"]
-    sp_name = "sipin"
 
     # The XSLT
     xslt_path = Path("metadata.xslt")
@@ -123,7 +122,6 @@ def create_sidecar(path: str, metadata: dict):
         etree.parse(str(metadata_path)),
         cp_id=etree.XSLT.strparam(cp_id),
         cp_name=etree.XSLT.strparam(cp_name),
-        sp_name=etree.XSLT.strparam(sp_name),
         pid=etree.XSLT.strparam(pid),
         original_filename=etree.XSLT.strparam(original_filename),
         md5=etree.XSLT.strparam(md5),

--- a/metadata.xslt
+++ b/metadata.xslt
@@ -2,13 +2,22 @@
     <xsl:output version="1.0" encoding="UTF-8" standalone="yes" indent="yes" />
     <xsl:param name="cp_name" />
     <xsl:param name="cp_id" />
-    <xsl:param name="sp_name" />
     <xsl:param name="pid" />
     <xsl:param name="original_filename" />
     <xsl:param name="md5" />
     <xsl:param name="premis_path" />
 
     <xsl:variable name="premis_source" select="document($premis_path)/premis:premis" />
+    <xsl:variable name="sp_name">
+        <xsl:choose>
+            <xsl:when test="$premis_source/premis:agent/premis:agentType[text()='SP Agent']">
+                <xsl:value-of select="$premis_source/premis:agent[premis:agentType/text()='SP Agent']/premis:agentName/text()" />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="'sipin'" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
 
     <xsl:template match="metadata">
         <mhs:Sidecar xmlns:mhs="https://zeticon.mediahaven.com/metadata/22.1/mhs/" xmlns:mh="https://zeticon.mediahaven.com/metadata/22.1/mh/" version="22.1">
@@ -139,7 +148,7 @@
                 <xsl:if test="$premis_source/premis:object[@xsi:type='premis:representation']/premis:storage/premis:storageMedium = 'XDCAM'">
                     <xsl:apply-templates select="$premis_source/premis:object[@xsi:type='premis:representation']/premis:storage/premis:storageMedium" />
                 </xsl:if>
-                <!-- SP name and SP ID-->
+                <!-- SP ID-->
                 <xsl:apply-templates select="$premis_source/premis:agent/premis:agentType[text() = 'SP Agent']" />
                 <!-- Digitization info-->
                 <xsl:apply-templates select="$premis_source/premis:event/premis:eventType[text() = 'DIGITIZATION']" />
@@ -700,11 +709,8 @@
             <xsl:value-of select="text()" />
         </xsl:element>
     </xsl:template>
-    <!-- SP name and SP ID-->
+    <!-- SP ID-->
     <xsl:template match="premis:agent/premis:agentType[text()='SP Agent']">
-        <xsl:element name="sp_name">
-            <xsl:value-of select="../premis:agentName/text()" />
-        </xsl:element>
         <xsl:element name="sp_id">
             <xsl:value-of select="../premis:agentIdentifier/premis:agentIdentifierValue/text()" />
         </xsl:element>

--- a/tests/resources/mhs.xml
+++ b/tests/resources/mhs.xml
@@ -8,7 +8,7 @@
     <ingest_workflow>sipin</ingest_workflow>
     <CP>CP name</CP>
     <CP_id>CP ID</CP_id>
-    <sp_name>SP name</sp_name>
+    <sp_name>sipin</sp_name>
     <PID>PID</PID>
     <md5>md5</md5>
     <dc_identifier_localid>localid</dc_identifier_localid>

--- a/tests/resources/mhs_xdcam.xml
+++ b/tests/resources/mhs_xdcam.xml
@@ -155,7 +155,6 @@
     <dc_description_programme>Programmabeschrijving</dc_description_programme>
     <ebu_objectType>Object type</ebu_objectType>
     <format>XDCAM</format>
-    <sp_name>SP name</sp_name>
     <sp_id>OR-id</sp_id>
     <digitization_date>2022-05-17</digitization_date>
     <digitization_time>11:50:13</digitization_time>

--- a/tests/test_medatata.py
+++ b/tests/test_medatata.py
@@ -22,7 +22,6 @@ def test_transform(premis_path, output_path):
     xslt_path = Path("metadata.xslt")
     cp_name = "CP name"
     cp_id = "CP ID"
-    sp_name = "SP name"
     pid = "PID"
     original_filename = "name"
     md5 = "md5"
@@ -34,7 +33,6 @@ def test_transform(premis_path, output_path):
         etree.parse(str(metadata_path)),
         cp_name=etree.XSLT.strparam(cp_name),
         cp_id=etree.XSLT.strparam(cp_id),
-        sp_name=etree.XSLT.strparam(sp_name),
         pid=etree.XSLT.strparam(pid),
         original_filename=etree.XSLT.strparam(original_filename),
         md5=etree.XSLT.strparam(md5),


### PR DESCRIPTION
In all cases, the `sp_name` is added in the mhs metadata with the hardcoded
value `sipin`. In the case of XDCAM, the `sp_name` is supplied in the
sidecar metadata which is also added in the mhs metadata. In short, in that
case, the `sp_name` element is added twice with different values.

The `sp_name` should be calculated:
 - Add the value from the supplied metadata if available;
 - Otherwise use the hardcoded value `sipin`.