### PR TITLE
DEV-2173 Add type_viaa in mhs metadata when XDCAM

### DIFF
--- a/metadata.xslt
+++ b/metadata.xslt
@@ -154,6 +154,12 @@
                 <xsl:apply-templates select="$premis_source/premis:event/premis:eventType[text() = 'DIGITIZATION']" />
                 <!-- Player info-->
                 <xsl:apply-templates select="$premis_source/premis:agent/premis:agentType[text() = 'player']" />
+                <!-- Set type_viaa to 'video' when XDCAM -->
+                <xsl:if test="$premis_source/premis:object[@xsi:type='premis:representation']/premis:storage/premis:storageMedium = 'XDCAM'">
+                    <xsl:element name="type_viaa">
+                        <xsl:value-of select="'video'" />
+                    </xsl:element>
+                </xsl:if>
             </xsl:element>
         </mhs:Sidecar>
     </xsl:template>

--- a/tests/resources/mhs_xdcam.xml
+++ b/tests/resources/mhs_xdcam.xml
@@ -162,5 +162,6 @@
     <player_manufacturer>SONY</player_manufacturer>
     <player_serial_number>0000000</player_serial_number>
     <player_model>PDW-U2</player_model>
+    <type_viaa>video</type_viaa>
   </mhs:Dynamic>
 </mhs:Sidecar>


### PR DESCRIPTION
Hardcode it to the value `video` as XDCAM is a digital video recording
format.