### PR TITLE
DEV-2172 Change sp_name to "borndigital"

### DIFF
--- a/metadata.xslt
+++ b/metadata.xslt
@@ -15,7 +15,7 @@
                 <xsl:value-of select="$premis_source/premis:agent[premis:agentType/text()='SP Agent']/premis:agentName/text()" />
             </xsl:when>
             <xsl:otherwise>
-                <xsl:value-of select="'sipin'" />
+                <xsl:value-of select="'borndigital'" />
             </xsl:otherwise>
         </xsl:choose>
     </xsl:variable>

--- a/tests/resources/mhs.xml
+++ b/tests/resources/mhs.xml
@@ -8,7 +8,7 @@
     <ingest_workflow>sipin</ingest_workflow>
     <CP>CP name</CP>
     <CP_id>CP ID</CP_id>
-    <sp_name>sipin</sp_name>
+    <sp_name>borndigital</sp_name>
     <PID>PID</PID>
     <md5>md5</md5>
     <dc_identifier_localid>localid</dc_identifier_localid>

--- a/tests/resources/mhs_batch_id.xml
+++ b/tests/resources/mhs_batch_id.xml
@@ -8,7 +8,7 @@
     <ingest_workflow>sipin</ingest_workflow>
     <CP>CP name</CP>
     <CP_id>CP ID</CP_id>
-    <sp_name>sipin</sp_name>
+    <sp_name>borndigital</sp_name>
     <PID>PID</PID>
     <md5>md5</md5>
     <dc_identifier_localid>localid</dc_identifier_localid>


### PR DESCRIPTION
Change `sp_name` to "borndigital" in order to roll out in PRD. The `sp_name` defines the workflow in MediaHaven. The PRD environment has not yet been updated to exclude the golden set check in case the workflow is "sipin".